### PR TITLE
Fixed temp file behaviour for Python 3 compatibility

### DIFF
--- a/atomictempfile/atomictempfile.py
+++ b/atomictempfile/atomictempfile.py
@@ -22,7 +22,8 @@ class AtomicTempFile (object): # pylint: disable=R0903
     tmpfile_dir = kwargs.pop ('dir', None)
     if tmpfile_dir is None:
       tmpfile_dir = os.path.dirname (final_path)
-    self.tmpfile = tempfile.NamedTemporaryFile (dir = tmpfile_dir, **kwargs)
+    self.tmpfile = tempfile.NamedTemporaryFile (dir = tmpfile_dir,
+                                                delete = False, **kwargs)
     self.final_path = final_path
 
   @logtool.log_call


### PR DESCRIPTION
It appears that named temp files are not automatically deleted when they're supposed to upon being closed in Python 2. This behaviour was fixed in Python 3, which causes `atomictempfile` to fail, as the temp file it wants to move has been deleted by the time it is able to get to it.

This PR corrects that behaviour.
